### PR TITLE
Fixing Issue #1

### DIFF
--- a/ponjika.go
+++ b/ponjika.go
@@ -117,7 +117,7 @@ func New(t time.Time) Ponjika {
 		BengaliYear:   BN{enToBnNumber(banglaYear), fmt.Sprintf("%v", banglaYear)},
 		BengaliMonth:  banglaMonth,
 		BengaliDate:   BN{enToBnNumber(banglaDate), fmt.Sprintf("%v", banglaDate)},
-		TotalDays:     monthDays,
+		TotalDays:     totalMonthDays[banglaMonthIndex],
 		Date:          banglaDate,
 		BengaliDay:    WeekDayList[int(localTime.Weekday())],
 		BengaliSeason: banglaSeason,

--- a/ponjika_test.go
+++ b/ponjika_test.go
@@ -195,7 +195,7 @@ func Test_BanglaMonthTotalDays(t *testing.T) {
 			ExpectedIndex: 30,
 		},
 		{
-			EnDate:         "2001-04-15 14:18:00",
+			EnDate:         "2018-04-15 14:18:00",
 			ExpectedIndex: 31,
 		},
 	}
@@ -206,7 +206,7 @@ func Test_BanglaMonthTotalDays(t *testing.T) {
 		} else {
 			p := New(d)
 			if p.TotalDays != tc.ExpectedIndex {
-				t.Errorf("Expected %d \nGot: %d", p.TotalDays, tc.ExpectedIndex)
+				t.Errorf("Expected %d \nGot: %d", tc.ExpectedIndex, p.TotalDays)
 			}
 		}
 	}

--- a/ponjika_test.go
+++ b/ponjika_test.go
@@ -183,3 +183,31 @@ func TestPonjika_Phonetic(t *testing.T) {
 		}
 	}
 }
+
+func Test_BanglaMonthTotalDays(t *testing.T) {
+	layout := "2006-01-02 15:04:05"
+	testCases := []struct {
+		EnDate string
+		ExpectedIndex int
+	}{
+		{
+			EnDate:         "2018-04-01 14:18:00",
+			ExpectedIndex: 30,
+		},
+		{
+			EnDate:         "2001-04-15 14:18:00",
+			ExpectedIndex: 31,
+		},
+	}
+	for _, tc := range testCases {
+		d, err := time.Parse(layout, tc.EnDate)
+		if err != nil {
+			t.Error("failed to parse english date time: ", err)
+		} else {
+			p := New(d)
+			if p.TotalDays != tc.ExpectedIndex {
+				t.Errorf("Expected %d \nGot: %d", p.TotalDays, tc.ExpectedIndex)
+			}
+		}
+	}
+}


### PR DESCRIPTION
`monthDays` value is actually used to calculate the Bangla date offset considering the English date. It is not reliable to produce the correct result of 'TotalDays' of current Bangla Month. 
So, instead of `monthDays`, we should return the  `totalMonthDays[banglaMonthIndex]`.